### PR TITLE
Fix Network Event collection

### DIFF
--- a/examples/bcc_sample.py
+++ b/examples/bcc_sample.py
@@ -325,18 +325,17 @@ class NetEvent(object):
 		if event_msg.union.net.proto == 17:
 			self.proto = "UDP"
 
-		# Should not have to run htons here oh well
-		self.sport = int(event_msg.union.net.sport)
-		self.dport = int(event_msg.union.net.dport)
+		self.sport = socket.ntohs(int(event_msg.union.net.sport))
+		self.dport = socket.ntohs(int(event_msg.union.net.dport))
 
 		if event_msg.ev_type == EVENT_TYPE.CONNECT_ACCEPT:
 			if event_msg.union.net.proto == 17:
-				self.sport = socket.htons(int(event_msg.union.net.sport))
-				self.dport = socket.htons(int(event_msg.union.net.dport))
+				self.sport = socket.ntohs(int(event_msg.union.net.sport))
+				self.dport = socket.ntohs(int(event_msg.union.net.dport))
 			self.flow = "rx"
 		elif event_msg.ev_type == EVENT_TYPE.CONNECT_PRE:
 			self.flow = "tx"
-			self.dport = socket.htons(int(event_msg.union.net.dport))
+			self.dport = socket.ntohs(int(event_msg.union.net.dport))
 
 		# AF_INET
 		if event_msg.union.net.ipver == socket.AF_INET:
@@ -358,6 +357,10 @@ class NetEvent(object):
 				event_msg.union.net.daddr6[2],
 				event_msg.union.net.daddr6[3],
 			)
+		else:
+			self.family = socket.AF_INET
+			self.pack_saddr = struct.pack("I", 0)
+			self.pack_daddr = struct.pack("I", 0)
 
 
 	def logstr(self):

--- a/examples/bcc_sample.py
+++ b/examples/bcc_sample.py
@@ -12,15 +12,15 @@ import argparse
 
 class NetEventData(ctypes.Structure):
 	_fields_ = [
-		('saddr', ctypes.c_uint),
-		('daddr', ctypes.c_uint),
-		('dport', ctypes.c_ushort),
-		('sport', ctypes.c_ushort),
+		('local_addr', ctypes.c_uint),
+		('remote_addr', ctypes.c_uint),
+		('remote_port', ctypes.c_ushort),
+		('local_port', ctypes.c_ushort),
 		('ipver', ctypes.c_ushort),
 		('proto', ctypes.c_ushort),
 		('dns_flag', ctypes.c_ushort),
-		('saddr6', ctypes.c_uint * 4),
-		('daddr6', ctypes.c_uint * 4),
+		('local_addr6', ctypes.c_uint * 4),
+		('remote_addr6', ctypes.c_uint * 4),
 		('dns', ctypes.c_char * 40),
 		('name_len', ctypes.c_uint),
 	]
@@ -319,48 +319,48 @@ class NetEvent(object):
 
 		self.flow = None
 		self.family = None
-		self.pack_saddr = None
-		self.pack_daddr = None
+		self.pack_local_addr = None
+		self.pack_remote_addr = None
 		self.proto = "TCP"
 		if event_msg.union.net.proto == 17:
 			self.proto = "UDP"
 
-		self.sport = socket.ntohs(int(event_msg.union.net.sport))
-		self.dport = socket.ntohs(int(event_msg.union.net.dport))
+		self.local_port = socket.ntohs(int(event_msg.union.net.local_port))
+		self.remote_port = socket.ntohs(int(event_msg.union.net.remote_port))
 
 		if event_msg.ev_type == EVENT_TYPE.CONNECT_ACCEPT:
 			if event_msg.union.net.proto == 17:
-				self.sport = socket.ntohs(int(event_msg.union.net.sport))
-				self.dport = socket.ntohs(int(event_msg.union.net.dport))
+				self.local_port = socket.ntohs(int(event_msg.union.net.local_port))
+				self.remote_port = socket.ntohs(int(event_msg.union.net.remote_port))
 			self.flow = "rx"
 		elif event_msg.ev_type == EVENT_TYPE.CONNECT_PRE:
 			self.flow = "tx"
-			self.dport = socket.ntohs(int(event_msg.union.net.dport))
+			self.remote_port = socket.ntohs(int(event_msg.union.net.remote_port))
 
 		# AF_INET
 		if event_msg.union.net.ipver == socket.AF_INET:
 			self.family = socket.AF_INET
-			self.pack_saddr = struct.pack("I", event_msg.union.net.saddr)
-			self.pack_daddr = struct.pack("I", event_msg.union.net.daddr)
+			self.pack_local_addr = struct.pack("I", event_msg.union.net.local_addr)
+			self.pack_remote_addr = struct.pack("I", event_msg.union.net.remote_addr)
 		# AF_INET6
 		elif event_msg.union.net.ipver == socket.AF_INET6:
 			self.family = socket.AF_INET6
-			self.pack_saddr = struct.pack("IIII",
-				event_msg.union.net.saddr6[0],
-				event_msg.union.net.saddr6[1],
-				event_msg.union.net.saddr6[2],
-				event_msg.union.net.saddr6[3],
+			self.pack_local_addr = struct.pack("IIII",
+				event_msg.union.net.local_addr6[0],
+				event_msg.union.net.local_addr6[1],
+				event_msg.union.net.local_addr6[2],
+				event_msg.union.net.local_addr6[3],
 			)
-			self.pack_daddr = struct.pack("IIII",
-				event_msg.union.net.daddr6[0],
-				event_msg.union.net.daddr6[1],
-				event_msg.union.net.daddr6[2],
-				event_msg.union.net.daddr6[3],
+			self.pack_remote_addr = struct.pack("IIII",
+				event_msg.union.net.remote_addr6[0],
+				event_msg.union.net.remote_addr6[1],
+				event_msg.union.net.remote_addr6[2],
+				event_msg.union.net.remote_addr6[3],
 			)
 		else:
 			self.family = socket.AF_INET
-			self.pack_saddr = struct.pack("I", 0)
-			self.pack_daddr = struct.pack("I", 0)
+			self.pack_local_addr = struct.pack("I", 0)
+			self.pack_remote_addr = struct.pack("I", 0)
 
 
 	def logstr(self):
@@ -369,10 +369,10 @@ class NetEvent(object):
 			self.ev_type_str,
 			self.proto,
 			self.pid,
-			socket.inet_ntop(self.family, self.pack_saddr),
-			self.sport,
-			socket.inet_ntop(self.family, self.pack_daddr),
-			self.dport,
+			socket.inet_ntop(self.family, self.pack_local_addr),
+			self.local_port,
+			socket.inet_ntop(self.family, self.pack_remote_addr),
+			self.remote_port,
 		)
 		return net_event_str
 


### PR DESCRIPTION
* Add logic to disable printing of event types
  * Add argparse support to control the example program
  * Add logic to suppress printing of disabled event types
* Change all netconn events to include the port in Network Byte Order
* Change the Collection logic to be consistent.
* TCP Accept
  * Use the check_family function to identify IPv4 or IPv6
* UDP Accept
  * Use the network header length to decide IPv4 or IPv6 (instead of bitmap manipulation)
  * Switch destination and source data to reflect local vs remote
* Improve Network Event names
  * Change saddr/sport to local_addr/local_port
  * Change daddr/dport to remote_addr/remote_port
  * This is to avoid confusion in the collection (because we are not strictly using it as source and destination)
  * Note: This does not change the struct alignment, so it will work with existing user collection applications