### PR TITLE
PSCLNX-6703 Fix truncated exec arg …

### DIFF
--- a/examples/bcc_sample.py
+++ b/examples/bcc_sample.py
@@ -76,6 +76,7 @@ class EventType(object):
 	DNS_RESPONSE = 12
 	WEB_PROXY = 13
 	FILE_DELETE = 14
+	FILE_CLOSE = 15
 
 	event_type_map = {
 		PROCESS_ARG : 'PROCESS_ARG',
@@ -91,6 +92,7 @@ class EventType(object):
 		DNS_RESPONSE : 'DNS_RESPONSE',
 		WEB_PROXY : 'WEB_PROXY',
 		FILE_DELETE : 'FILE_DELETE',
+		FILE_CLOSE : 'FILE_CLOSE',
 	}
 
 	enabled_types_map = {
@@ -108,6 +110,7 @@ class EventType(object):
 		DNS_RESPONSE : True,
 		WEB_PROXY : True,
 		FILE_DELETE : True,
+		FILE_CLOSE : True,
 	}
 
 	PP_NO_EXTRA_DATA = 0
@@ -132,6 +135,7 @@ class EventType(object):
 		self.enabled_types_map[self.FILE_WRITE] = not args.disable_file
 		self.enabled_types_map[self.FILE_CREATE] = not args.disable_file
 		self.enabled_types_map[self.FILE_DELETE] = not args.disable_file
+		self.enabled_types_map[self.FILE_CLOSE] = not args.disable_file
 		self.enabled_types_map[self.PROCESS_ARG] = not args.disable_process
 		self.enabled_types_map[self.PROCESS_EXEC] = not args.disable_process
 		self.enabled_types_map[self.PROCESS_EXIT] = not args.disable_process
@@ -496,7 +500,8 @@ def perf_event_cb(cpu, data, size):
 		elif (event_msg.ev_type == EVENT_TYPE.FILE_WRITE or
 			  event_msg.ev_type == EVENT_TYPE.FILE_MMAP or
 			  event_msg.ev_type == EVENT_TYPE.FILE_CREATE or
-			  event_msg.ev_type == EVENT_TYPE.FILE_DELETE):
+			  event_msg.ev_type == EVENT_TYPE.FILE_DELETE or
+			  event_msg.ev_type == EVENT_TYPE.FILE_CLOSE):
 			ret = handle_file_event(event_msg)
 			if ret:
 				print(ret)


### PR DESCRIPTION
### Add BPF_LRU macro
* Follows the form for other BPF_XXXX macros, so should work if it is ever added
* Defaults to BPF_HASH on kernels that do not support the LRU

### Do some cleanup in the probe …
* Convert some additional items from dport to remote_port, etc...
* Remove the defines for TCP and UDP
* Update the data field
  * Convert the xxx_addr6 fields to a union with the v4 field
  * Deprecate the old v4 field, but leave it in the struct
  * Continue to set the old v4 field
* Ignore the local port in the cache to help de-dup netconn events
  * Note: This is a behavior change for Ent. EDR

### Fix truncated exec arg
* Example Script
  * Rename PP_FINALIZE to PP_FINALIZED (to match probe)
  * Add logic to append data to the arg string without prefixing
  * Handle new `PP_APPEND` state, and allow `PP_DEBUG` state
* Probe
  * Update logic to detect when an arg is longer than the buffer, and send the remainder in the next message

### Add support for file close after write