### PR TITLE
CB-32814: replace __vfs_write with other functions

### DIFF
--- a/src/bcc_sensor.c
+++ b/src/bcc_sensor.c
@@ -836,6 +836,85 @@ out:
     return 0;
 }
 
+// This is mainly for kernel > 5.8.0
+int trace_write_kentry(struct pt_regs *ctx,
+                      struct file *   file,
+                      const void  *   buf,
+                      size_t       count)
+{
+    struct data_t data = {};
+    struct super_block *sb = NULL;
+    struct inode *inode = NULL;
+    int mode;
+
+    if (!file)
+    {
+        goto out;
+    }
+
+    sb = _sb_from_file(file);
+    if (!sb)
+    {
+        goto out;
+    }
+
+    if (__is_special_filesystem(sb))
+    {
+        goto out;
+    }
+
+    bpf_probe_read(&inode, sizeof(inode), &(file->f_inode));
+    if (!inode)
+    {
+        goto out;
+    }
+    bpf_probe_read(&mode, sizeof(mode), &(inode->i_mode));
+    if (!S_ISREG(mode))
+    {
+        goto out;
+    }
+    __set_key_entry_data(&data, file);
+    __set_device_from_sb(&data, sb);
+
+    u64 file_cache_key = (u64)file;
+
+    void *cachep = file_write_cache.lookup(&file_cache_key);
+    if (cachep)
+    {
+            struct file_data cache_data = *((struct file_data *)cachep);
+            pid_t pid = cache_data.pid;
+            cache_data.pid = data.pid;
+
+        // if we really care about that multiple tasks
+        // these are likely threads or less likely inherited from a fork
+        if (pid == data.pid)
+        {
+            goto out;
+        }
+
+        file_write_cache.update(&file_cache_key, &cache_data);
+        goto out;
+    }
+    else
+    {
+            struct file_data cache_data = {
+                    .pid    = data.pid,
+                    .device = data.device,
+                    .inode  = data.inode
+            };
+        file_write_cache.insert(&file_cache_key, &cache_data);
+    }
+
+    data.state = PP_ENTRY_POINT;
+    data.type = EVENT_FILE_WRITE;
+    events.perf_submit(ctx, &data, sizeof(data));
+
+    __do_file_path(ctx, file->f_path.dentry, file->f_path.mnt, &data);
+    events.perf_submit(ctx, &data, sizeof(data));
+out:
+    return 0;
+}
+
 // This hook may not be very accurate but at least tells us the intent
 // to create the file if needed. So this will likely be written to next.
 int on_security_file_open(struct pt_regs *ctx, struct file *file)


### PR DESCRIPTION
__vfs_write would be deprecated and removed from Linux
kernel version 5.8.0. This is taken care by

* check if __vfs_write symbol exists in /proc/kallsyms
  If present (kernel < 5.8.0), attach the probe
  Else attach probes for two functions from fs/read_write.c
  one if vfs_write and other is __kernel_write.

* The probe callback function code is duplicated for now.

Signed-off-by: Kiran Divekar <dkiran@vmware.com>