### PR TITLE
Add ability to track file opens for reporting script interpreter events

### DIFF
--- a/examples/bcc_sample.go
+++ b/examples/bcc_sample.go
@@ -407,6 +407,7 @@ const (
 	evWebProxy      = 13
 	evFileDelete    = 14
 	evFileClose     = 15
+	evFileOpen	= 16
 )
 
 type stateType uint8
@@ -437,7 +438,8 @@ func printEventByType(eventType uint8) string {
 		"DNS_RESPONSE",
 		"WEB_PROXY",
 		"FILE_DELETE",
-		"FILE_CLOSE"}
+		"FILE_CLOSE",
+		"FILE_OPEN"}
 	if len(eventNames) >= int(eventType) {
 		return eventNames[eventType]
 	}
@@ -467,7 +469,7 @@ func parsePrintEvent(kevent sensorEvent) {
 	case evDNSResponse, evWebProxy:
 		result = handleDNSEvent(kevent)
 
-	case evFileWrite, evFileMmap, evFileCreate, evFileDelete, evFileClose:
+	case evFileWrite, evFileMmap, evFileCreate, evFileDelete, evFileClose, evFileOpen:
 		result = handleFileEvent(kevent)
 	}
 	if len(result) > 0 {

--- a/examples/bcc_sample.py
+++ b/examples/bcc_sample.py
@@ -77,6 +77,7 @@ class EventType(object):
 	WEB_PROXY = 13
 	FILE_DELETE = 14
 	FILE_CLOSE = 15
+	FILE_OPEN = 16
 
 	event_type_map = {
 		PROCESS_ARG : 'PROCESS_ARG',
@@ -94,6 +95,7 @@ class EventType(object):
 		WEB_PROXY : 'WEB_PROXY',
 		FILE_DELETE : 'FILE_DELETE',
 		FILE_CLOSE : 'FILE_CLOSE',
+		FILE_OPEN: 'FILE_OPEN'
 	}
 
 	enabled_types_map = {
@@ -112,6 +114,7 @@ class EventType(object):
 		WEB_PROXY : True,
 		FILE_DELETE : True,
 		FILE_CLOSE : True,
+		FILE_OPEN: True
 	}
 
 	PP_NO_EXTRA_DATA = 0
@@ -137,6 +140,7 @@ class EventType(object):
 		self.enabled_types_map[self.FILE_CREATE] = not args.disable_file
 		self.enabled_types_map[self.FILE_DELETE] = not args.disable_file
 		self.enabled_types_map[self.FILE_CLOSE] = not args.disable_file
+		self.enabled_types_map[self.FILE_OPEN] = not args.disable_file
 		self.enabled_types_map[self.PROCESS_ARG] = not args.disable_process
 		self.enabled_types_map[self.PROCESS_EXEC] = not args.disable_process
 		self.enabled_types_map[self.PROCESS_EXIT] = not args.disable_process
@@ -498,7 +502,8 @@ def perf_event_cb(cpu, data, size):
 			  event_msg.ev_type == EVENT_TYPE.FILE_MMAP or
 			  event_msg.ev_type == EVENT_TYPE.FILE_CREATE or
 			  event_msg.ev_type == EVENT_TYPE.FILE_DELETE or
-			  event_msg.ev_type == EVENT_TYPE.FILE_CLOSE):
+			  event_msg.ev_type == EVENT_TYPE.FILE_CLOSE or
+			  event_msg.ev_type == EVENT_TYPE.FILE_OPEN):
 			ret = handle_file_event(event_msg)
 			if ret:
 				print(ret)


### PR DESCRIPTION
Adds support for tracking certain file opens, which can be used to detect scriptloads.
* Expands the event type enum to include a new type for file opens
* Determines if event is file-create/file-open/uninteresting based on additional file flags
* Restricts the file caching to the file-create only case