### PR TITLE
CB-33768: Fixed RHEL8.3 build before tagging for EDR release

### DIFF
--- a/src/bcc_sensor.c
+++ b/src/bcc_sensor.c
@@ -18,6 +18,10 @@
 #define randomized_struct_fields_end    };
 #endif
 
+#ifndef KBUILD_MODNAME
+#define KBUILD_MODNAME "vmw_bcc_bpfsensor"
+#endif
+
 #include <uapi/linux/limits.h>
 #include <uapi/linux/in.h>
 #include <uapi/linux/ip.h>


### PR DESCRIPTION
Added KBUILD_MODNAME to support RHEL8.3 build.