### PR TITLE
Fill In Event Context Data For Exec Ret Probes

### DIFF
--- a/src/bcc_sensor.c
+++ b/src/bcc_sensor.c
@@ -631,10 +631,7 @@ int syscall__on_sys_execve(struct pt_regs *ctx, const char __user *filename,
 //Note that this can be called more than one from the same pid
 int after_sys_execve(struct pt_regs *ctx)
 {
-	struct task_struct *task;
 	struct data_t data = {};
-	u64 *start_time = NULL;
-	u32 *ppid = NULL;
 
 	__set_key_entry_data(&data, NULL);
 	data.event_time = bpf_ktime_get_ns();


### PR DESCRIPTION
The event context and unique identifiers were not all being set on execve and execve return values. This will allow for easier exec event building when BPF messages are read out of order.

Signed-off-by: Jeffery Wooldridge <jwooldridge@vmware.com>