### PR TITLE
Remove struct randomization re-definition for 4.14 kernels

### DIFF
--- a/src/bcc_sensor.c
+++ b/src/bcc_sensor.c
@@ -3,10 +3,10 @@
  * SPDX-License-Identifier: GPL-2.0
  */
 
-// Struct randomization causes issues on 4.13 and some versions of 4.14
+// Struct randomization causes issues on 4.13 and some early versions of 4.14
 // These are redefined to work around this, per:
 // https://lists.iovisor.org/g/iovisor-dev/topic/21386300#1239
-#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 15, 0)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 14, 0)
 #ifdef randomized_struct_fields_start
 #undef randomized_struct_fields_start
 #endif


### PR DESCRIPTION
While some of the early 4.14 kernels may be subject to the struct randomization issue, it was patched in later versions. As a result, the logic here is causing data accuracy issues against Amazon Linux (4.14.77) because the re-definition is not required.

Signed-off-by: Deanna Baris <dbaris@vmware.com>