### PR TITLE
Handle Basic File Rename Events

### DIFF
--- a/examples/bcc_sample.go
+++ b/examples/bcc_sample.go
@@ -1,5 +1,5 @@
 //
-// Copyright 2020 VMware, Inc.
+// Copyright 2020-20201 VMware, Inc.
 // SPDX-License-Identifier: BSD-2-Clause
 //
 
@@ -92,6 +92,11 @@ var allProbes = []probeMeta{
 	probeMeta{
 		PP:          "security_inode_unlink",
 		PPCbName:    "on_security_inode_unlink",
+		IsKretProbe: false,
+	},
+	probeMeta{
+		PP:          "security_inode_rename",
+		PPCbName:    "on_security_inode_rename",
 		IsKretProbe: false,
 	},
 

--- a/examples/bcc_sample.py
+++ b/examples/bcc_sample.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright 2020 VMware, Inc.
+# Copyright 2020-2021 VMware, Inc.
 # SPDX-License-Identifier: BSD-2-Clause
 #
 
@@ -585,6 +585,10 @@ def attach_probes(bcc):
 		Probe(
 			pp='security_inode_unlink',
 			pp_cb_name='on_security_inode_unlink',
+		),
+		Probe(
+			pp='security_inode_rename',
+			pp_cb_name='on_security_inode_rename',
 		),
 
 		# execve and execveat syscalls


### PR DESCRIPTION
Creates a file delete event for the old dentry and a file create event for the "new" dentry. Removes entry from file_map if it exists.

On kernels with CONFIG_SECURITY_PATH enabled we we probably could make these paths more reliable. I would view that as a different initiative.

Signed-off-by: Jeffery Wooldridge <jwooldridge@vmware.com>