### PR TITLE
Remove kernel 5.5 gating around bpf_probe_read_str

### DIFF
--- a/src/bcc_sensor.c
+++ b/src/bcc_sensor.c
@@ -81,10 +81,7 @@
 //   while the old version returns 0 on success.  Some of the logic we use does depend on the non-zero result
 //   (described later).
 #if LINUX_VERSION_CODE < KERNEL_VERSION(4, 11, 0)
-#define bpf_probe_read_kernel_str bpf_probe_read
 #define bpf_probe_read_str bpf_probe_read
-#elif LINUX_VERSION_CODE < KERNEL_VERSION(5, 5, 0)
-#define bpf_probe_read_kernel_str bpf_probe_read_str
 #endif
 #endif
 
@@ -379,11 +376,11 @@ static inline void __set_key_entry_data(struct data_t *data, struct file *file)
 
 static u8 __submit_arg(struct pt_regs *ctx, void *ptr, struct data_t *data)
 {
-	// Note: On some kernels bpf_probe_read_kernel_str does not exist.  In this case it is
+	// Note: On some kernels bpf_probe_read_str does not exist.  In this case it is
 	//  substituted by bpf_probe_read.  The return value for these two cases mean something
 	//  different, but that is OK for our logic.
 	// Note: On older kernel this may read past the actual arg list into the env.
-	u8 result = bpf_probe_read_kernel_str(data->fname, MAX_FNAME, ptr);
+	u8 result = bpf_probe_read_str(data->fname, MAX_FNAME, ptr);
 	events.perf_submit(ctx, data, sizeof(struct data_t));
 	return result;
 }


### PR DESCRIPTION
Fixes an issue where on the latest release of Ubuntu 20.04 (running a 5.8 kernel),
`bpf_probe_read_kernel_str` would fail to correctly copy data into the data_t struct.
Using `bpf_probe_read_str` works on earlier kernels (including 5.4 in the prior release
of Ubuntu 20.04), so I've updated to not use the kernel read variant at all.

Signed-off-by: Dom Bozzuto <dbozzuto@vmware.com>