### PR TITLE
PSCLNX-8176 Fix Net Event Issue

### DIFF
--- a/src/bcc_sensor.c
+++ b/src/bcc_sensor.c
@@ -1390,6 +1390,8 @@ int trace_skb_recv_udp(struct pt_regs *ctx)
 			return 0;
 		}
 #endif /* CACHE_UDP */
+	} else {
+	    return 0;
 	}
 
 	events.perf_submit(ctx, &data, sizeof(data));


### PR DESCRIPTION
* The UDP CONNECT_ACCEPT path has logic to detect IPv4 vs IPv6 based on header size.
  However if neither header matches, it was still sending an event. (With invalid data.)