### PR TITLE
Fix an issue where the device could not get reported in the rename hook

### DIFF
--- a/src/bcc_sensor.c
+++ b/src/bcc_sensor.c
@@ -1019,7 +1019,8 @@ int on_security_inode_rename(struct pt_regs *ctx,
 	if (inode) {
 		bpf_probe_read(&data.inode, sizeof(data.inode), &inode->i_ino);
 	}
-	__set_device_from_sb(&data, new_sb);
+    
+    __set_device_from_sb(&data, new_sb ? new_sb : old_sb);
 	events.perf_submit(ctx, &data, sizeof(data));
 	__do_dentry_path(ctx, new_dentry, &data);
 	events.perf_submit(ctx, &data, sizeof(data));


### PR DESCRIPTION
In the path where no overwrite occurred, `new_sb` would still be null when deriving the
device. This now prefers the new superblock if it has been set (an overwrite is occuring),
but falls back to the old superblock if not.

Signed-off by: Dom Bozzuto <dbozzuto@vmware.com>